### PR TITLE
Fix some problems to the API

### DIFF
--- a/api/conf.h
+++ b/api/conf.h
@@ -16,7 +16,12 @@ namespace zia::api
     */
     struct ConfValue
     {
-        std::variant<ConfObject, ConfArray, std::string, long long, double, bool> v;
+        using Parameter = std::variant<ConfObject, ConfArray, std::string, long long, double, bool>;
+
+        Parameter value;
+
+        explicit ConfValue(const Parameter &param) : value{param} {}
+        virtual ~ConfValue() = default;
     };
 
     /**

--- a/api/conf.h
+++ b/api/conf.h
@@ -5,24 +5,25 @@
 #include <variant>
 #include <vector>
 
-namespace zia::api {
-	struct ConfValue;
-	using ConfObject = std::map<std::string, ConfValue>;
-	using ConfArray = std::vector<ConfValue>;
+namespace zia::api
+{
+    struct ConfValue;
+    using ConfObject = std::map<std::string, ConfValue>;
+    using ConfArray = std::vector<ConfValue>;
 
-	/**
-	* Represents a configuration value.
-	*/
-	struct ConfValue
-	{
+    /**
+    * Represents a configuration value.
+    */
+    struct ConfValue
+    {
         std::variant<ConfObject, ConfArray, std::string, long long, double, bool> v;
     };
 
-	/**
-	* Configuration (format influenced by JSON).
-	* Configuration must contain:
-	*  - "modules": a list of modules name e.g. "cgibin", "gzip", "logger" (extension will be appended, will be prefixed by "lib" on linux)
-	*  - "modules_path": a list of paths to look for modules e.g. ".", "modules"
-	*/
-	using Conf = ConfObject;
+    /**
+    * Configuration (format influenced by JSON).
+    * Configuration must contain:
+    *  - "modules": a list of modules name e.g. "cgibin", "gzip", "logger" (extension will be appended, will be prefixed by "lib" on linux)
+    *  - "modules_path": a list of paths to look for modules e.g. ".", "modules"
+    */
+    using Conf = ConfObject;
 }

--- a/api/conf.h
+++ b/api/conf.h
@@ -16,7 +16,7 @@ namespace zia::api
     */
     struct ConfValue
     {
-        using Parameter = std::variant<ConfObject, ConfArray, std::string, long long, double, bool>;
+        using Parameter = std::variant<std::monostate, ConfObject, ConfArray, std::string, long long, double, bool>;
 
         Parameter value;
 

--- a/api/http.h
+++ b/api/http.h
@@ -27,7 +27,15 @@ namespace zia::api
     {
         enum class Method
         {
-            unknown, options, get, head, post, put, delete_, trace, connect
+            unknown = 0,
+            options = 1,
+            get = 2,
+            head = 3,
+            post = 4,
+            put = 5,
+            delete_ = 6,
+            trace = 7,
+            connect = 8
         };
 
         Method method;

--- a/api/http.h
+++ b/api/http.h
@@ -21,9 +21,10 @@ namespace zia::api
         };
 
         Version version;
-        std::map <std::string, std::string> headers;
+        std::map<std::string, std::string> headers;
         Net::Raw body;
 
+        HttpMessage() : version{Version::unknown}, headers{}, body{} {}
         virtual ~HttpMessage() = default;
     };
 
@@ -44,6 +45,9 @@ namespace zia::api
 
         Method method;
         std::string uri;
+
+        HttpRequest() : HttpMessage(), method{Method::unknown}, uri{} {}
+        ~HttpRequest() override = default;
     };
 
     struct HttpResponse : public HttpMessage
@@ -94,6 +98,9 @@ namespace zia::api
         };
 
         Status status;
+
+        HttpResponse() : HttpMessage(), status{Status::unknown} {}
+        ~HttpResponse() override = default;
     };
 
     /**
@@ -104,5 +111,8 @@ namespace zia::api
         NetInfo info;
         HttpRequest req;
         HttpResponse resp;
+
+        HttpDuplex() = default;
+        virtual ~HttpDuplex() = default;
     };
 }

--- a/api/http.h
+++ b/api/http.h
@@ -98,8 +98,6 @@ namespace zia::api
     struct HttpDuplex
     {
         NetInfo info;
-        Net::Raw raw_req;
-        Net::Raw raw_resp;
         HttpRequest req;
         HttpResponse resp;
     };

--- a/api/http.h
+++ b/api/http.h
@@ -4,87 +4,95 @@
 #include <map>
 #include <string>
 
-namespace zia::api {
-	/**
-	* Base class for requests and responses.
-	*/
-	struct HttpMessage {
-		enum class Version {
-			unknown, http_0_9, http_1_0, http_1_1, http_2_0
-		};
+namespace zia::api
+{
+    /**
+    * Base class for requests and responses.
+    */
+    struct HttpMessage
+    {
+        enum class Version
+        {
+            unknown, http_0_9, http_1_0, http_1_1, http_2_0
+        };
 
-		Version version;
-		std::map<std::string, std::string> headers;
-		Net::Raw body;
+        Version version;
+        std::map <std::string, std::string> headers;
+        Net::Raw body;
 
-		virtual ~HttpMessage() = default;
-	};
+        virtual ~HttpMessage() = default;
+    };
 
-	struct HttpRequest : public HttpMessage {
-		enum class Method {
-			unknown, options, get, head, post, put, delete_, trace, connect
-		};
+    struct HttpRequest : public HttpMessage
+    {
+        enum class Method
+        {
+            unknown, options, get, head, post, put, delete_, trace, connect
+        };
 
-		Method method;
-		std::string uri;
-	};
+        Method method;
+        std::string uri;
+    };
 
-	struct HttpResponse : public HttpMessage {
-		enum class Status {
-			unknown,
-			continue_ = 100,
-			switching_protocols = 101,
-			ok = 200,
-			created = 201,
-			accepted = 202,
-			nonauthoritative_information = 203,
-			no_content = 204,
-			reset_content = 205,
-			partial_content = 206,
-			multiple_choices = 300,
-			moved_permanently = 301,
-			found = 302,
-			see_other = 303,
-			not_modified = 304,
-			use_proxy = 305,
-			temporary_redirect = 307,
-			bad_request = 400,
-			unauthorized = 401,
-			payment_required = 402,
-			forbidden = 403,
-			not_found = 404,
-			method_not_allowed = 405,
-			not_acceptable = 406,
-			proxy_authentication_required = 407,
-			request_timeout = 408,
-			conflict = 409,
-			gone = 410,
-			length_required = 411,
-			precondition_failed = 412,
-			request_entity_too_large = 413,
-			request_uri_too_large = 414,
-			unsupported_media_type = 415,
-			requested_range_not_satisfiable = 416,
-			expectation_failed = 417,
-			internal_server_error = 500,
-			not_implemented = 501,
-			bad_gateway = 502,
-			service_unavailable = 503,
-			gateway_timeout = 504,
-			http_version_not_supported = 505
-		};
+    struct HttpResponse : public HttpMessage
+    {
+        enum class Status
+        {
+            unknown,
+            continue_ = 100,
+            switching_protocols = 101,
+            ok = 200,
+            created = 201,
+            accepted = 202,
+            nonauthoritative_information = 203,
+            no_content = 204,
+            reset_content = 205,
+            partial_content = 206,
+            multiple_choices = 300,
+            moved_permanently = 301,
+            found = 302,
+            see_other = 303,
+            not_modified = 304,
+            use_proxy = 305,
+            temporary_redirect = 307,
+            bad_request = 400,
+            unauthorized = 401,
+            payment_required = 402,
+            forbidden = 403,
+            not_found = 404,
+            method_not_allowed = 405,
+            not_acceptable = 406,
+            proxy_authentication_required = 407,
+            request_timeout = 408,
+            conflict = 409,
+            gone = 410,
+            length_required = 411,
+            precondition_failed = 412,
+            request_entity_too_large = 413,
+            request_uri_too_large = 414,
+            unsupported_media_type = 415,
+            requested_range_not_satisfiable = 416,
+            expectation_failed = 417,
+            internal_server_error = 500,
+            not_implemented = 501,
+            bad_gateway = 502,
+            service_unavailable = 503,
+            gateway_timeout = 504,
+            http_version_not_supported = 505
+        };
 
-		Status status;
-	};
+        Status status;
+    };
 
-	/**
-	* Represents a request and its response during pipeline processing.
-	*/
-	struct HttpDuplex {
-		NetInfo info;
-		Net::Raw raw_req;
-		Net::Raw raw_resp;
-		HttpRequest req;
-		HttpResponse resp;
-	};
+    /**
+    * Represents a request and its response during pipeline processing.
+    */
+    struct HttpDuplex
+    {
+        NetInfo info;
+        Net::Raw raw_req;
+        Net::Raw raw_resp;
+        HttpRequest req;
+        HttpResponse resp;
+    };
 }

--- a/api/http.h
+++ b/api/http.h
@@ -13,7 +13,11 @@ namespace zia::api
     {
         enum class Version
         {
-            unknown, http_0_9, http_1_0, http_1_1, http_2_0
+            unknown = 0,
+            http_0_9 = 1,
+            http_1_0 = 2,
+            http_1_1 = 3,
+            http_2_0 = 4
         };
 
         Version version;

--- a/api/module.h
+++ b/api/module.h
@@ -3,25 +3,27 @@
 #include "conf.h"
 #include "http.h"
 
-namespace zia::api {
-	/**
-	 * Interface for modules. Functions must be safe in a multithreading context.
-	 * Dynamic libraries of modules must export a "create" C function returning a "Module*" (caller should use smart pointers).
-	 */
-	class Module {
-	public:
-		virtual ~Module() = default;
+namespace zia::api
+{
+    /**
+     * Interface for modules. Functions must be safe in a multithreading context.
+     * Dynamic libraries of modules must export a "create" C function returning a "Module*" (caller should use smart pointers).
+     */
+    class Module
+    {
+    public:
+        virtual ~Module() = default;
 
-		/**
-		* Called after contruct and when config changed.
-		* \return true on success, otherwise false.
-		*/
-		virtual bool config(const Conf& conf) = 0;
+        /**
+        * Called after contruct and when config changed.
+        * \return true on success, otherwise false.
+        */
+        virtual bool config(const Conf &conf) = 0;
 
-		/**
-		* Called on HTTP request.
-		* \return true on success, otherwise false.
-		*/
-		virtual bool exec(HttpDuplex& http) = 0;
-	};
+        /**
+        * Called on HTTP request.
+        * \return true on success, otherwise false.
+        */
+        virtual bool exec(HttpDuplex &http) = 0;
+    };
 }

--- a/api/net.h
+++ b/api/net.h
@@ -6,6 +6,7 @@
 #include <functional>
 #include <string>
 #include <vector>
+#include <memory>
 
 namespace zia::api
 {
@@ -34,7 +35,7 @@ namespace zia::api
         NetIp ip;
         std::uint16_t port;
 
-        ImplSocket *sock;
+        std::shared_ptr<ImplSocket> sock;
 
         NetInfo() : time{}, start{}, ip{}, port{}, sock{} {}
         virtual ~NetInfo() = default;
@@ -71,7 +72,7 @@ namespace zia::api
         * Send a response.
         * \return true on success, otherwise false
         */
-        virtual bool send(ImplSocket *sock, Raw resp) = 0;
+        virtual bool send(std::shared_ptr<ImplSocket> sock, Raw resp) = 0;
 
         /**
         * Stop the server.

--- a/api/net.h
+++ b/api/net.h
@@ -7,67 +7,71 @@
 #include <string>
 #include <vector>
 
-namespace zia::api {
-	/**
-	* Represents an IPv4 address.
-	*/
-	struct NetIp {
-		std::uint32_t i;
-		std::string str;
-	};
+namespace zia::api
+{
+    /**
+    * Represents an IPv4 address.
+    */
+    struct NetIp
+    {
+        std::uint32_t i;
+        std::string str;
+    };
 
-	/**
-	* Struct identifying socket (implementation-defined).
-	*/
-	struct ImplSocket;
+    /**
+    * Struct identifying socket (implementation-defined).
+    */
+    struct ImplSocket;
 
-	/**
-	* Infos on client.
-	*/
-	struct NetInfo {
-		std::chrono::system_clock::time_point time;
-		std::chrono::steady_clock::time_point start;
+    /**
+    * Infos on client.
+    */
+    struct NetInfo
+    {
+        std::chrono::system_clock::time_point time;
+        std::chrono::steady_clock::time_point start;
 
-		NetIp ip;
-		std::uint16_t port;
+        NetIp ip;
+        std::uint16_t port;
 
-		ImplSocket* sock;
-	};
+        ImplSocket *sock;
+    };
 
-	/**
-	* Interface for multithreaded network abstraction.
-	* Dynamic library implementing it must export a "create" C function returning a "Net*" (caller should use smart pointers).
-	*/
-	class Net {
-	public:
-		/**
-		* Type used to receive and send packets.
-		*/
-		using Raw = std::vector<std::byte>;
+    /**
+    * Interface for multithreaded network abstraction.
+    * Dynamic library implementing it must export a "create" C function returning a "Net*" (caller should use smart pointers).
+    */
+    class Net
+    {
+    public:
+        /**
+        * Type used to receive and send packets.
+        */
+        using Raw = std::vector<std::byte>;
 
-		/**
-		* Type of callback called on request.
-		*/
-		using Callback = std::function<void(Raw, NetInfo)>;
+        /**
+        * Type of callback called on request.
+        */
+        using Callback = std::function<void(Raw, NetInfo)>;
 
-		virtual ~Net() = default;
+        virtual ~Net() = default;
 
-		/**
-		* Launch the server asynchronously, callback will be called when a request is received.
-		* \return true on success, otherwise false
-		*/
-		virtual bool run(Callback cb) = 0;
+        /**
+        * Launch the server asynchronously, callback will be called when a request is received.
+        * \return true on success, otherwise false
+        */
+        virtual bool run(Callback cb) = 0;
 
-		/**
-		* Send a response.
-		* \return true on success, otherwise false
-		*/
-		virtual bool send(ImplSocket* sock, Raw resp) = 0;
+        /**
+        * Send a response.
+        * \return true on success, otherwise false
+        */
+        virtual bool send(ImplSocket *sock, Raw resp) = 0;
 
-		/**
-		* Stop the server.
-		* \return true on success, otherwise false
-		*/
-		virtual bool stop() = 0;
-	};
+        /**
+        * Stop the server.
+        * \return true on success, otherwise false
+        */
+        virtual bool stop() = 0;
+    };
 }

--- a/api/net.h
+++ b/api/net.h
@@ -47,7 +47,7 @@ namespace zia::api
         /**
         * Type used to receive and send packets.
         */
-        using Raw = std::vector<std::byte>;
+        using Raw = std::string;
 
         /**
         * Type of callback called on request.

--- a/api/net.h
+++ b/api/net.h
@@ -35,6 +35,9 @@ namespace zia::api
         std::uint16_t port;
 
         ImplSocket *sock;
+
+        NetInfo() : time{}, start{}, ip{}, port{}, sock{} {}
+        virtual ~NetInfo() = default;
     };
 
     /**
@@ -53,6 +56,8 @@ namespace zia::api
         * Type of callback called on request.
         */
         using Callback = std::function<void(Raw, NetInfo)>;
+
+        Net() = default;
 
         virtual ~Net() = default;
 


### PR DESCRIPTION
 - Fix indentation because it wasn't uniform
 - Put value to enum because different compiler may change them
 - Remove duplicate Raw data because of duplication in HttpMessage and in HttpDuplex
 - Add constructor to all structs to initialize values because different compiler may change them
 - Add destructor to all structs especially in inheritence cases
 - Add smart pointer with `std::shared_ptr` because modern c++
 - Add std::monostate to std::variant because of recursive-uses
 - Change `std::vector<std::byte>` to `std::string` because HTTP is a text protocol so it can handle it and `std::string` is more user-friendly and cleaner for that purpose