### PR TITLE
Adding type hint function

### DIFF
--- a/api/module.h
+++ b/api/module.h
@@ -25,3 +25,11 @@ namespace zia::api {
         virtual bool exec(HttpDuplex& http) = 0;
     };
 }
+
+enum ModuleType: int {
+    Unknown = -1,
+    Module = 0,
+    Network = 1
+};
+
+extern "C" ModuleType type();


### PR DESCRIPTION
## Problem

In current version of the api, no hint is given to choose whether the loaded module is a Network module or a processing module.

## Solution(s) given

In order to make hit easier to load the correct type of module (different return type of create() function) a simple extern C function have been added and indicate which type of module it actually is.

Another (cleaner way) to make it more logical would be to have two differents symbols (ex: createModule and createNet) that would only be implemented depending on the needs of the module. The major disadvantage of this method would be to change symbols already described in current documentation (however, I doubt that it would be a problem a this stade of the project).

Tell me if you prefer the second option and want me to change this pull request.

Greetings